### PR TITLE
Fix turn counting mistakes

### DIFF
--- a/2023/scripts/run_validation/README.md
+++ b/2023/scripts/run_validation/README.md
@@ -38,6 +38,8 @@ This is a summary of the checks that the script performs on a run file.
  * Does the run file have at least one turn? 
  * Is the `run_name` field non-empty?
  * Is the `run_type` field non-empty and set to `automatic` or `manual`?
+ * Does the number of turns in the run match the number in the test topics file?
+ * Does the number of turns in each topic in the run match the corresponding number in the test topics file?
  * For each turn in the run:
    * Is the turn ID valid and matches an entry in the topics file?
    * Is any turn ID higher than expected for the selected topic (e.g. turns 1-5 in the topic, but a turn has ID 6 in the run file)?
@@ -69,4 +71,4 @@ python3 generate_run.py <path to run file>
 
 ## Tests
 
-There are some tests provided along with the validation script in the `tests` directory. To run them, use `pytest` from the `run_validation` directory, or `pytest --runslow` to run all tests including those that won't complete immediately. 
+There are some tests provided along with the validation script in the `tests` directory. To run them, use `pytest` from the `run_validation` directory.

--- a/2023/scripts/run_validation/main.py
+++ b/2023/scripts/run_validation/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from pathlib import PurePath
-from typing import Tuple, Union, Any
+from typing import Tuple, Union, Any, List
 
 import grpc
 from google.protobuf.json_format import ParseDict
@@ -104,7 +104,7 @@ def load_run_file(run_file_path: str) -> iKATRun:
 
     return run
 
-def validate_turn(turn: Turn, topic_data: dict[str, Any], stub: Union[None, PassageValidatorStub], timeout: float) -> Tuple[int, int]:
+def validate_turn(turn: Turn, ptkb_data: dict[str, Any], stub: Union[None, PassageValidatorStub], timeout: float) -> Tuple[int, int]:
     """
     Validate a single turn from a run.
 
@@ -145,7 +145,6 @@ def validate_turn(turn: Turn, topic_data: dict[str, Any], stub: Union[None, Pass
         if len(response.passage_provenance) == 0:
             logger.warning(f'Turn {turn.turn_id} has a response with no passage provenances')
             warning_count += 1
-
         elif len(response.passage_provenance) > 1000:
             logger.warning(f'Turn {turn.turn_id} has a response with >1000 passages ({len(response.passage_provenance)})')
             warning_count += 1
@@ -153,16 +152,70 @@ def validate_turn(turn: Turn, topic_data: dict[str, Any], stub: Union[None, Pass
         if len(response.ptkb_provenance) == 0:
             logger.warning(f'No PTKB provenances listed for a response in turn {turn.turn_id}!')
             warning_count += 1
-            break 
+            continue # no point in doing the next block 
 
         prev_ptkb_score = 1e9
-        ptkbs = topic_data['ptkb']
 
         for ptkb_prov in response.ptkb_provenance:
-            warning_count += check_ptkb_provenance(ptkb_prov, turn, ptkbs, prev_ptkb_score, logger)
+            warning_count += check_ptkb_provenance(ptkb_prov, turn, ptkb_data, prev_ptkb_score, logger)
             prev_ptkb_score = ptkb_prov.score
 
     return warning_count, service_errors
+
+def validate_all_turns(run: iKATRun, topics_dict: dict[str, dict[str, Any]]) -> dict[str, List[Turn]]:
+    """
+    Given a run file, verify the number of turns.
+
+    This involves:
+        1. Checking that the total number of turns matches the test topics file
+        2. Checking that there are the correct number of turns for each topic
+
+    To make subsequent topic-by-topic validation simpler, this will also pull out
+    the list of individual turns for each topic and return those. 
+    """
+    
+    # we already know the number of turns in topics_dict is correct after checking
+    # that in the load_topic_data method. so here we need to first check the number
+    # of turns in the run matches that...
+
+    if len(run.turns) != EXPECTED_RUN_TURN_COUNT:
+        logger.error(f'The run contains {len(run.turns)} turns, but the test topics contain {EXPECTED_RUN_TURN_COUNT} turns')
+        sys.exit(255)
+
+    run_topics_dict: dict[str, List[Turn]] = {}
+    for turn in run.turns:
+        # check if the turn ID looks valid
+        try:
+            topic_id, turn_id = turn.turn_id.split('_')
+            turn_id = int(turn_id)
+        except Exception as e:
+            logger.error(f'Failed to parse turn ID "{turn.turn_id}", exception was {e}')
+            sys.exit(255)
+
+        if topic_id not in run_topics_dict:
+            run_topics_dict[topic_id] = []
+
+        run_topics_dict[topic_id].append(turn)
+
+    # check we have the expected number of topics from the run file
+    if len(run_topics_dict) != EXPECTED_TOPIC_ENTRIES:
+        logger.error(f'The run contains {len(run_topics_dict)} topics, the expected number is {EXPECTED_TOPIC_ENTRIES}')
+        sys.exit(255)
+
+    # check each topic has the expected number of turns, and that each
+    # expected topic appears in the run
+    for topic_id, topic_data in topics_dict.items():
+        if topic_id not in run_topics_dict:
+            logger.error(f'The topic {topic_id} does not appear in the run file')
+            sys.exit(255)
+
+        expected_turns = len(topic_data['turns'])
+        actual_turns = len(run_topics_dict[topic_id])
+        if expected_turns != actual_turns:
+            logger.error(f'The topic {topic_id} should have {expected_turns} turns but actually has {actual_turns} turns')
+            sys.exit(255)
+
+    return run_topics_dict
 
 def validate_run(run: iKATRun, topics_dict: dict[str, dict[str, Any]], stub: Union[None, PassageValidatorStub], max_warnings: int, timeout: float) -> Tuple[int, int, int]:
     """
@@ -181,37 +234,19 @@ def validate_run(run: iKATRun, topics_dict: dict[str, dict[str, Any]], stub: Uni
         logger.warning('Run has an unrecognised type, should be "automatic" or "manual"!')
         total_warnings += 1
 
-    for turn in run.turns:
-        # check if the turn ID is valid
-        try:
+    run_topics_dict = validate_all_turns(run, topics_dict)
+
+    for topic_id, topic_data in run_topics_dict.items():
+        for turn in topic_data:
             topic_id, turn_id = turn.turn_id.split('_')
-        except Exception as e:
-            logger.warning(f'Failed to parse turn ID "{turn.turn_id}", exception was {e}')
-            total_warnings += 1
-            continue
+            turn_id = int(turn_id)
 
-        if topic_id not in topics_dict:
-            logger.warning(f'Turn {turn.turn_id} has an topic ID ({topic_id}) that is not in the topics JSON file!')
-            total_warnings += 1
-            continue # probably not worth doing anything else with this turn
-
-        topic_data = topics_dict[topic_id]
-        num_turns = len(topic_data['turns'])
-        try:
-            turn_id_int = int(turn_id)
-        except ValueError:
-            logger.error(f'Failed to parse turn ID {turn_id} as an integer')
-            sys.exit(255)
-
-        if turn_id_int > num_turns:
-            logger.error(f'Turn {turn.turn_id} has a turn ID higher than the number of expected turns ({turn_id} > {num_turns})')
-            sys.exit(255)
-
-        if len(run.turns) != num_turns:
-            logger.error(f'The run contains {len(run.turns)} turns, but the topic contains {num_turns} turns')
+            max_turn_id = len(topics_dict[topic_id]['turns'])
+            if turn_id < 1 or turn_id > max_turn_id:
+                logger.error(f'Turn {turn.turn_id} has an invalid turn ID {turn_id}, expected range: 1-{max_turn_id}')
                 sys.exit(255)
 
-        _warnings, _service_errors = validate_turn(turn, topic_data, stub, timeout)
+            _warnings, _service_errors = validate_turn(turn, topics_dict[topic_id]['ptkb'], stub, timeout)
             total_warnings += _warnings
             service_errors += _service_errors
             turns_validated += 1

--- a/2023/scripts/run_validation/main.py
+++ b/2023/scripts/run_validation/main.py
@@ -300,7 +300,7 @@ if __name__ == '__main__':
     ap.add_argument('path_to_run_file')
     ap.add_argument('-f', '--fileroot', help='Location of data files', default='../../data')
     ap.add_argument('-S', '--skip_passage_validation', help='Skip passage ID validation', action='store_true')
-    ap.add_argument('-m', '--max_warnings', help='Maximum number of warnings to allow', type=int, default=25) 
+    ap.add_argument('-m', '--max_warnings', help='Maximum number of warnings to allow', type=int, default=2000) 
     ap.add_argument('-t', '--timeout', help='Set the gRPC timeout (secs) for contacting the validation service', default=GRPC_DEFAULT_TIMEOUT, type=float)
     args = ap.parse_args()
 

--- a/2023/scripts/run_validation/tests/test_main.py
+++ b/2023/scripts/run_validation/tests/test_main.py
@@ -1,15 +1,25 @@
-import os
-import sys
 import copy
+import os
 import pathlib
+import sys
 
 import pytest
 
-from main import get_stub, load_topic_data, load_run_file
-from main import validate_turn, validate_run, validate, GRPC_DEFAULT_TIMEOUT, EXPECTED_TOPIC_ENTRIES
+from main import (
+    EXPECTED_RUN_TURN_COUNT,
+    EXPECTED_TOPIC_ENTRIES,
+    GRPC_DEFAULT_TIMEOUT,
+    get_stub,
+    load_run_file,
+    load_topic_data,
+    validate,
+    validate_run,
+    validate_turn,
+)
+
 
 def test_get_stub(grpc_server_test):
-    assert(get_stub() is not None)
+    assert(get_stub(port=8099) is not None)
 
 def test_load_topic_data(topic_data_file: str):
     topic_data = load_topic_data(topic_data_file)
@@ -32,8 +42,9 @@ def test_load_missing_topic_data():
     with pytest.raises(Exception, match='Topics file foobar not found'):
         _ = load_topic_data('foobar')
 
-def test_load_run_file(run_file_path: str):
-    load_run_file(run_file_path)
+def test_load_run_file(baseline_run_file: str):
+    run = load_run_file(baseline_run_file)
+    assert(len(run.turns) == EXPECTED_RUN_TURN_COUNT)
 
 def test_validate_invalid_run_file(tmp_path: pathlib.PurePath):
     tmp_file = tmp_path / 'invalid.json'
@@ -48,7 +59,7 @@ def test_validate_invalid_run_file(tmp_path: pathlib.PurePath):
     assert pytest_exc.type == SystemExit
     assert pytest_exc.value.code == 255
 
-def test_validate_run_file_missing_run_name(tmp_path: pathlib.PurePath, run_file_path: str):
+def test_validate_run_file_missing_run_name(tmp_path: pathlib.PurePath):
     tmp_file = tmp_path / 'missing_run_name.json'
     json_str = '{ "run_type": "manual", "turns": [] }'
 
@@ -61,7 +72,7 @@ def test_validate_run_file_missing_run_name(tmp_path: pathlib.PurePath, run_file
     assert pytest_exc.type == SystemExit
     assert pytest_exc.value.code == 255
 
-def test_validate_run_file_missing_turns(tmp_path: pathlib.PurePath, run_file_path: str):
+def test_validate_run_file_missing_turns(tmp_path: pathlib.PurePath):
     tmp_file = tmp_path / 'missing_turns.json'
     json_str = '{ "run_type": "manual", "run_name": "missing_turns"}'
 
@@ -78,31 +89,31 @@ def test_validate_missing_run_file():
     with pytest.raises(OSError):
         _ = load_run_file('foobar')
 
-def test_validate_turn(topic_data_file, run_file_path: str, grpc_stub_test, sample_turn):
+def test_validate_turn(topic_data_file: str, grpc_stub_full, sample_turn):
     topic_data = load_topic_data(topic_data_file)
     topic_id = sample_turn.turn_id.split('_')[0]
-    warnings, service_errors = validate_turn(sample_turn, topic_data[topic_id], grpc_stub_test, GRPC_DEFAULT_TIMEOUT)
-    assert(warnings == 0)
+    warnings, service_errors = validate_turn(sample_turn, topic_data[topic_id], grpc_stub_full, GRPC_DEFAULT_TIMEOUT)
+    assert(warnings == 6) # no passages marked as used, no PTKBs, for each response
     assert(service_errors == 0)
 
-def test_validate_run(topic_data_file, run_file_path: str, grpc_stub_test, default_validate_args):
+def test_validate_run(topic_data_file: str, baseline_run_file: str, grpc_stub_full, default_validate_args):
     args = default_validate_args
+    args.max_warnings = 1992
     topic_data = load_topic_data(topic_data_file)
-    run = load_run_file(run_file_path)
-    assert(len(run.turns) == 6)
+    run = load_run_file(baseline_run_file)
+    assert(len(run.turns) == EXPECTED_RUN_TURN_COUNT)
     
-    turns_validated, service_errors, total_warnings = validate_run(run, topic_data, grpc_stub_test, args.max_warnings, args.timeout)
+    turns_validated, service_errors, total_warnings = validate_run(run, topic_data, grpc_stub_full, args.max_warnings, args.timeout)
 
-    assert(turns_validated == 6)
+    assert(turns_validated == EXPECTED_RUN_TURN_COUNT)
     assert(service_errors == 0)
-    assert(total_warnings == 0)
+    assert(total_warnings == 1992)
 
-@pytest.mark.slow
-def test_validate_run_invalid(topic_data_file, run_file_path: str, grpc_stub_test_invalid, default_validate_args):
+def test_validate_run_invalid(topic_data_file, baseline_run_file: str, grpc_stub_test_invalid, default_validate_args):
     args = default_validate_args
     topic_data = load_topic_data(topic_data_file)
-    run = load_run_file(run_file_path)
-    assert(len(run.turns) == 6)
+    run = load_run_file(baseline_run_file)
+    assert(len(run.turns) == EXPECTED_RUN_TURN_COUNT)
 
     # test that the script exits when it can't contact the grpc service
     with pytest.raises(SystemExit) as pytest_exc:
@@ -111,94 +122,56 @@ def test_validate_run_invalid(topic_data_file, run_file_path: str, grpc_stub_tes
     assert pytest_exc.type == SystemExit
     assert pytest_exc.value.code == 255
 
-def test_validate_run_no_service(topic_data_file, run_file_path: str, default_validate_args):
+def test_validate_run_no_service(topic_data_file: str, baseline_run_file: str, default_validate_args):
     args = default_validate_args
+    args.max_warnings = 1992
     topic_data = load_topic_data(topic_data_file)
-    run = load_run_file(run_file_path)
-    assert(len(run.turns) == 6)
+    run = load_run_file(baseline_run_file)
+    assert(len(run.turns) == EXPECTED_RUN_TURN_COUNT)
     
     turns_validated, service_errors, total_warnings = validate_run(run, topic_data, None, args.max_warnings, args.timeout)
-    assert(turns_validated == 6)
+    assert(turns_validated == EXPECTED_RUN_TURN_COUNT)
     assert(service_errors == 0)
-    assert(total_warnings == 0)
+    assert(total_warnings == 1992)
 
-@pytest.mark.slow
 def test_validate(default_validate_args, grpc_server_full):
     args = default_validate_args
+    args.max_warnings = 1992
 
     turns_validated, service_errors, total_warnings = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
-    assert(turns_validated == 6)
+    assert(turns_validated == EXPECTED_RUN_TURN_COUNT)
     assert(service_errors == 0)
-    assert(total_warnings == 0) 
+    assert(total_warnings == 1992)
 
-@pytest.mark.slow
-def test_validate_no_service(default_validate_args, grpc_server_full):
+def test_validate_no_service(default_validate_args, grpc_server_full_alt):
     args = default_validate_args
 
     # terminate the service
-    grpc_server_full.stop(None)
+    grpc_server_full_alt.stop(None)
 
-    turns_validated, service_errors, total_warnings = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
-    assert(turns_validated == 6)
-    assert(service_errors == 6)
-    assert(total_warnings == 0) 
+    with pytest.raises(SystemExit) as pytest_exc:
+        turns_validated, service_errors, total_warnings = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
+    assert(pytest_exc.type == SystemExit)
+    assert(pytest_exc.value.code == 255)
 
-@pytest.mark.slow
-def test_validate_no_service_skip_validation(default_validate_args, grpc_server_full):
+def test_validate_no_service_skip_validation(default_validate_args, grpc_server_full_alt):
     args = default_validate_args
     args.skip_passage_validation = True
+    args.max_warnings = 2000
 
     # terminate the service
-    grpc_server_full.stop(None)
+    grpc_server_full_alt.stop(None)
 
     turns_validated, service_errors, total_warnings = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
-    assert(turns_validated == 6)
+    assert(turns_validated == EXPECTED_RUN_TURN_COUNT)
     assert(service_errors == 0)
-    assert(total_warnings == 0) 
+    assert(total_warnings == 1992) # total number of warnings about no PTKBs and no "used" passages
 
 def test_validate_empty(default_validate_args):
     args = default_validate_args
     args.path_to_run_file = 'foobar'
     with pytest.raises(FileNotFoundError):
         _, _, _ = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
-
-def test_validate_small(default_validate_args, grpc_server_test):
-    args = default_validate_args
-    
-    # this should abort after generating enough warnings, since the smaller database won't match most of the IDs
-    #with pytest.raises(SystemExit) as pytest_exc:
-    turns_validated, service_errors, total_warnings = validate(args.path_to_run_file, args.fileroot, args.max_warnings, args.skip_passage_validation, args.timeout)
-    assert(turns_validated == 6)
-    assert(service_errors == 0)
-    assert(total_warnings == 0)
-
-def test_validate_passages_used(default_validate_args, grpc_stub_test, topic_data_file: str, run_file_path: str):
-    # check that we get warnings if no passages in the provenance list are marked as "used"
-    args = default_validate_args
-    topic_data = load_topic_data(topic_data_file)
-    run = load_run_file(run_file_path)
-    assert(len(run.turns) == 6)
-
-    # update the first 2 turns to have no "used" passages
-    for i in range(2):
-        for response in run.turns[i].responses:
-            for pprov in response.passage_provenance:
-                pprov.used = False
-    
-    turns_validated, service_errors, total_warnings = validate_run(run, topic_data, grpc_stub_test, args.max_warnings, args.timeout)
-
-    assert(turns_validated == 6)
-    assert(service_errors == 0)
-    assert(total_warnings == 6) # 3 responses in each turn in the sample file
-
-def test_validate_no_ptkb_results(default_validate_args, grpc_stub_test, topic_data_file: str, run_file_path_no_ptkb: str):
-    args = default_validate_args
-    topic_data = load_topic_data(topic_data_file)
-    run = load_run_file(run_file_path_no_ptkb)
-
-    turns_validated, _, total_warnings = validate_run(run, topic_data, grpc_stub_test, args.max_warnings, args.timeout)
-    assert(turns_validated == len(run.turns))
-    assert(total_warnings == len(run.turns)) # should be 1 warning per turn
 
 def test_validate_non_numeric_scores(default_validate_args, run_file_path_invalid_scores: str):
     args = default_validate_args

--- a/2023/scripts/run_validation/tests/test_utils.py
+++ b/2023/scripts/run_validation/tests/test_utils.py
@@ -13,10 +13,10 @@ def build_request(ids):
 def get_invalid_indices(response):
     return [i for i, pv in enumerate(response.passage_validations) if not pv.is_valid]
 
-def test_validate_passages(grpc_stub_test, test_logger, sample_turn):
-    assert(validate_passages(grpc_stub_test, test_logger, sample_turn, GRPC_DEFAULT_TIMEOUT) == 0)
+def test_validate_passages(grpc_stub_full, test_logger, sample_turn):
+    assert(validate_passages(grpc_stub_full, test_logger, sample_turn, GRPC_DEFAULT_TIMEOUT) == 0)
 
-def test_validate_too_many_passages(grpc_stub_test, test_logger, sample_turn, topic_data_file):
+def test_validate_too_many_passages(grpc_stub_full, test_logger, sample_turn, topic_data_file):
     # add extra passages to each response
     num_responses = len(sample_turn.responses)
     passages = []
@@ -33,9 +33,10 @@ def test_validate_too_many_passages(grpc_stub_test, test_logger, sample_turn, to
     topic_data = load_topic_data(topic_data_file)
     topic_id = sample_turn.turn_id.split('_')[0]
 
-    # this should produce 1 warning per response due to the number of passages listed being >1k
-    warning_count, service_errors = validate_turn(sample_turn, topic_data[topic_id], grpc_stub_test, GRPC_DEFAULT_TIMEOUT)
-    assert(warning_count == len(sample_turn.responses))
+    # this should produce 2 warnings per response due to the number of passages listed being >1k
+    # and not having any PTKB entries
+    warning_count, service_errors = validate_turn(sample_turn, topic_data[topic_id], grpc_stub_full, GRPC_DEFAULT_TIMEOUT)
+    assert(warning_count == len(sample_turn.responses) * 2)
     assert(service_errors == 0)
 
 def test_all_invalid_ids(grpc_stub_test):


### PR DESCRIPTION
This should fix a mistake in the original version of the script caused by my not understanding that a run wouldn't just contain the turns for a single topic. 

The script should now check the number of turns in the run against the `2023_test_topics.json` file, and also check the number of turns in each topic is correct. 